### PR TITLE
Feature/539 adapt get data endpoint for lezzoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,5 @@
-# Mintlify Starter Kit
+# Truemetrics API Docs
+Source code for Truemetrics API docs website, https://docu.truemetrics.cloud/.
 
-Click on `Use this template` to copy the Mintlify starter kit. The starter kit contains examples including
-
-- Guide pages
-- Navigation
-- Customizations
-- API Reference pages
-- Use of popular components
-
-### 👩‍💻 Development
-
-Install the [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the documentation changes locally. To install, use the following command
-
-```
-npm i -g mintlify
-```
-
-Run the following command at the root of your documentation (where mint.json is)
-
-```
-mintlify dev
-```
-
-### 😎 Publishing Changes
-
-Changes will be deployed to production automatically after pushing to the default branch.
-
-You can also preview changes using PRs, which generates a preview link of the docs.
-
-#### Troubleshooting
-
-- Mintlify dev isn't running - Run `mintlify install` it'll re-install dependencies.
-- Page loads as a 404 - Make sure you are running in a folder with `mint.json`
+## Credit
+This website built with [Mintlify](https://mintlify.com/)

--- a/api-reference/endpoint/deliveries.mdx
+++ b/api-reference/endpoint/deliveries.mdx
@@ -29,7 +29,7 @@ description: "This endpoint provides access to insights about your historical de
 
 ```bash Example Request
 
-curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-06_1' \
+curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/id_example_external' \
 --header 'x-api-key: YOURKEY' \
 --header 'Content-Type: application/json'
 ```
@@ -60,14 +60,14 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-
           1699225863
         ],
         "number_of_events": 1,
-        "id_phone": "fec492d8-1cf4-4565-ab91-83ef160f3f71",
+        "id_phone": "",
         "ids_address": [],
         "version_sequencing": "v2",
         "lats_reference_external": [
           59.40858
         ],
-        "id_stop": "d55d0767adacfbcfa86e94e007cde0d1bd091abde9455a08b131c8b8f44abdd8",
-        "hash_deliveries": "c434c6868ea29bfd747d1af4ab4d7b302edf48388983cb9a65e7238c83d8ad06",
+        "id_stop": "asda321sdasdasd342324a",
+        "hash_deliveries": "asda321sdasdasd342324a",
         "t_utc_created": 1701252019.442101,
         "t_end": [
           24.6864472502
@@ -78,7 +78,7 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-
         "t_start": 1699225817.83503,
         "use_labels": false,
         "ids_all_delivery_external": [
-          "c1_2023-11-06_1"
+          "id_example_external"
         ],
         "lats_event": [
           59.408449692
@@ -97,7 +97,7 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-
         "lons_reference_external": [
           24.68667
         ],
-        "id_delivery_external": "c1_2023-11-06_1",
+        "id_delivery_external": "id_example_external",
         "coords_parking": {
           "lat": 59.4084750686,
           "lon": 24.6864458694
@@ -121,14 +121,14 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-
           1699226268
         ],
         "number_of_events": 1,
-        "id_phone": "fec492d8-1cf4-4565-ab91-83ef160f3f71",
+        "id_phone": "id_phone_example",
         "ids_address": [],
         "version_sequencing": "v2",
         "lats_reference_external": [
           59.39821
         ],
-        "id_stop": "254f1e2e84f84f91ccf5e7c23bc7ca2543bc7c8431eaad5a01de31243cb06b1a",
-        "hash_deliveries": "c434c6868ea29bfd747d1af4ab4d7b302edf48388983cb9a65e7238c83d8ad06",
+        "id_stop": "id_stop_example",
+        "hash_deliveries": "asda321sdasdasd342324a",
         "t_utc_created": 1701252202.920812,
         "t_end": [
           24.6468801512
@@ -139,7 +139,7 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-
         "t_start": 1699226203.1683023,
         "use_labels": false,
         "ids_all_delivery_external": [
-          "c1_2023-11-06_1"
+          "id_example_external"
         ],
         "lats_event": [
           59.3983149706
@@ -158,7 +158,7 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-
         "lons_reference_external": [
           24.647078
         ],
-        "id_delivery_external": "c1_2023-11-06_1",
+        "id_delivery_external": "id_example_external",
         "coords_parking": {
           "lat": 59.3983578,
           "lon": 24.6468601

--- a/api-reference/endpoint/deliveries.mdx
+++ b/api-reference/endpoint/deliveries.mdx
@@ -29,7 +29,7 @@ description: "This endpoint provides access to insights about your historical de
 
 ```bash Example Request
 
-curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/02ba969157efe246129b586b736f4e276e6de5d77b726bb550449519966c1360' \
+curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/c1_2023-11-06_1' \
 --header 'x-api-key: YOURKEY' \
 --header 'Content-Type: application/json'
 ```
@@ -40,60 +40,138 @@ curl --location 'https://api.truemetrics.cloud/V2/results/deliveries/02ba969157e
 
 ```json Response
 {
-    "results": [
-        {
-            "hash_consignee": null,
-            "service_outdoors_from_customer": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "arrival": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "service_outdoors_to_customer": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "stop": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "created": "1688553899.8072311878204345703125",
-            "streetnumber": "80",
-            "postalcode": "12345",
-            "country": "DE",
-            "id_phone": "my_phone_id",
-            "picking": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "adress_raw": "Meine Adressse ist hier",
-            "service_indoors": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "id_customer": "my_customer_id",
-            "locality": "Berlin",
-            "coords_street": {
-                "lat": "0",
-                "lon": "0"
-            },
-            "service_outdoors": {
-                "dt": "0",
-                "t_start": "1688553899.8072311878204345703125"
-            },
-            "adress_hash": "9628136c6bd3054b71f00913f99fbdbd7a2d12707691514922f76e157c2963a3",
-            "coords_delivery": {
-                "lat": "0",
-                "lon": "0"
-            },
-            "id_delivery": "02ba969157efe246129b586b736f4e276e6de5d77b726bb550449519966c1360",
-            "id_tour": "9e7846a214a74a7cdddaf6143d61b45fb8ed70326f47462066afb7d5643e8229",
-            "street": "my_street"
-        }
+  "statusCode": 200,
+  "headers": {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true
+  },
+  "body": {
+    "stops": [
+      {
+        "ts": [
+          1699225817.83503,
+          1699225834.979354,
+          1699225841.0302918,
+          1699225897.5057118,
+          1699225918.6839943,
+          1699225937.8452976
+        ],
+        "ts_event": [
+          1699225863
+        ],
+        "number_of_events": 1,
+        "id_phone": "fec492d8-1cf4-4565-ab91-83ef160f3f71",
+        "ids_address": [],
+        "version_sequencing": "v2",
+        "lats_reference_external": [
+          59.40858
+        ],
+        "id_stop": "d55d0767adacfbcfa86e94e007cde0d1bd091abde9455a08b131c8b8f44abdd8",
+        "hash_deliveries": "c434c6868ea29bfd747d1af4ab4d7b302edf48388983cb9a65e7238c83d8ad06",
+        "t_utc_created": 1701252019.442101,
+        "t_end": [
+          24.6864472502
+        ],
+        "types_event": [
+          "pickup"
+        ],
+        "t_start": 1699225817.83503,
+        "use_labels": false,
+        "ids_all_delivery_external": [
+          "c1_2023-11-06_1"
+        ],
+        "lats_event": [
+          59.408449692
+        ],
+        "states": [
+          "START",
+          "S",
+          "C",
+          "S2",
+          "F",
+          "END"
+        ],
+        "lons_event": [
+          24.6864472502
+        ],
+        "lons_reference_external": [
+          24.68667
+        ],
+        "id_delivery_external": "c1_2023-11-06_1",
+        "coords_parking": {
+          "lat": 59.4084750686,
+          "lon": 24.6864458694
+        },
+        "t_service_indoors": 0,
+        "t_service_outdoors": 77.6537024974823,
+        "t_picking": 6.05093789100647,
+        "t_total": 83.70464038848877,
+        "t_stop": 83.70464038848877
+      },
+      {
+        "ts": [
+          1699226203.1683023,
+          1699226222.1939633,
+          1699226224.1966643,
+          1699226277.268245,
+          1699226943.1663785,
+          1699226952.1785338
+        ],
+        "ts_event": [
+          1699226268
+        ],
+        "number_of_events": 1,
+        "id_phone": "fec492d8-1cf4-4565-ab91-83ef160f3f71",
+        "ids_address": [],
+        "version_sequencing": "v2",
+        "lats_reference_external": [
+          59.39821
+        ],
+        "id_stop": "254f1e2e84f84f91ccf5e7c23bc7ca2543bc7c8431eaad5a01de31243cb06b1a",
+        "hash_deliveries": "c434c6868ea29bfd747d1af4ab4d7b302edf48388983cb9a65e7238c83d8ad06",
+        "t_utc_created": 1701252202.920812,
+        "t_end": [
+          24.6468801512
+        ],
+        "types_event": [
+          "delivery"
+        ],
+        "t_start": 1699226203.1683023,
+        "use_labels": false,
+        "ids_all_delivery_external": [
+          "c1_2023-11-06_1"
+        ],
+        "lats_event": [
+          59.3983149706
+        ],
+        "states": [
+          "START",
+          "S",
+          "C",
+          "S2",
+          "F",
+          "END"
+        ],
+        "lons_event": [
+          24.6468801512
+        ],
+        "lons_reference_external": [
+          24.647078
+        ],
+        "id_delivery_external": "c1_2023-11-06_1",
+        "coords_parking": {
+          "lat": 59.3983578,
+          "lon": 24.6468601
+        },
+        "t_service_indoors": 0,
+        "t_service_outdoors": 718.9697141647339,
+        "t_picking": 2.0027010440826416,
+        "t_total": 720.9724152088165,
+        "t_stop": 720.9724152088165
+      }
     ],
-    "message": "successfully retrieved 1 entries."
+    "message": "Successfully requested delivery."
+  }
 }
 ```
 

--- a/api-reference/endpoint/entrances.mdx
+++ b/api-reference/endpoint/entrances.mdx
@@ -1,25 +1,13 @@
 ---
 title: "Entrances"
-api: "GET https://api.truemetrics.cloud/V2/results/entrances/"
+api: "GET https://api.truemetrics.cloud/V2/results/entrances/{id_customer}"
 description: "This endpoint gives access to the entrances by its address. "
 ---
 
 ### Query Parameters
 
-<ParamField query="street" type="string" initialValue="my_street">
-  Name of the Street
-</ParamField>
-<ParamField query="streetnumber" type="string" initialValue="80">
-  Streetnumber of the address.
-</ParamField>
-<ParamField query="locality" type="string" initialValue= "Berlin">
-  Locality of the address.
-</ParamField>
-<ParamField query="postalcode" type="string" initialValue= "12345">
-  Postcal code of the address.
-</ParamField>
-<ParamField query="country" type="string" initialValue= "DE">
-  TCountry code in ISO 3166-1 alpha-2 format.
+<ParamField query="id_customer" type="string">
+  `id` number of the customer, as a string.
 </ParamField>
 
 <ParamField header="Content-Type" type="string" initialValue='application/json' >
@@ -38,13 +26,11 @@ description: "This endpoint gives access to the entrances by its address. "
 </ResponseField>
 
 <RequestExample>
-
 ```bash Example Request
-curl --location 'https://api.truemetrics.cloud/V2/results/parkingplaces?street=my_street&streetnumber=80&locality=Berlin&postalcode=12345&country=DE' \
+curl --location 'https://api.truemetrics.cloud/V2/results/entrances?id_customer=12345' \
 --header 'x-api-key: YOURKEY' \
 --header 'Content-Type: application/json'
 ```
-
 </RequestExample>
 
 <ResponseExample>
@@ -53,38 +39,15 @@ curl --location 'https://api.truemetrics.cloud/V2/results/parkingplaces?street=m
 {
     "results": [
         {
-            "polygon_entrance": [
+            "entrances": [
                 {
-                    "lat": "0",
-                    "lon": "0"
+                    "lat": "0.0",
+                    "lon": "0.0"
                 }
-            ],
-            "hash_consignee": null,
-            "id_entrance": "bc4e4fb281da041c5bfa51a03eaee5e9b1cfe39f9394396121f7044a1b107761",
-            "created": "1688553899.8072311878204345703125",
-            "streetnumber": "80",
-            "postalcode": "12345",
-            "country": "DE",
-            "id_phone": "my_phone_id",
-            "adress_raw": "Meine Adressse ist hier",
-            "coords_entrance": {
-                "lat": "0",
-                "lon": "0"
-            },
-            "id_customer": "my_customer_id",
-            "locality": "Berlin",
-            "coords_street": {
-                "lat": "0",
-                "lon": "0"
-            },
-            "adress_hash": "9628136c6bd3054b71f00913f99fbdbd7a2d12707691514922f76e157c2963a3",
-            "id_delivery": "my_delivery_id",
-            "id_tour": "my_route_id",
-            "street": "my_street"
+            ]
         }
     ],
-    "message": "successfully retrieved 1 entries."
+    "message": "Successfully retrieved entrances for this id_customer."
 }
 ```
-
 </ResponseExample>

--- a/mint.json
+++ b/mint.json
@@ -42,7 +42,9 @@
     {
       "group": "API Documentation",
       "pages": [
-        "api-reference/endpoint/parkingPlaces", "api-reference/endpoint/deliveries",  "api-reference/endpoint/entrances"
+        "api-reference/endpoint/parkingPlaces",
+        "api-reference/endpoint/deliveries",
+        "api-reference/endpoint/entrances"
       ]
     }
   ],

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -8,7 +8,7 @@ description: 'Start the integration in less than 5 minutes.'
 Learn how to integrate the truemetrics Android SDK into your app.
 The other sections of this document describe in detail how to integrate and use the SDK in your application. 
 
-## Gey your SDK API key
+## Get your SDK API key
 
 For using the SDK to upload data from the integrating app (e.g. your driver app), an API key is required.
 The integrating app has to set this api key (called SDK API KEY) in the initialization of the SDK (see also [here in the documentation](/functions)). 


### PR DESCRIPTION
Changes included in this PR:
- Replaced `Mintlify` boilerplate `README` with truemetrics info.
- Added `entrances` endpoint documentation.
- Updated `deliveries` endpoint documentation.

Note to reviewer (@JBisc): Please review the `id_delivery` used in the `deliveries` endpoint documentation, and replace with something that's not private customer data.