### PR TITLE
Update starting recording note

### DIFF
--- a/functions.mdx
+++ b/functions.mdx
@@ -145,10 +145,6 @@ TruemetricsSDK.startRecording()
 
 Starting the recording also starts Foreground service and shows notification supplied in `Config` in system's status bar. Recording will continue even when app exits.
 
-**Note**
-
-If you need to start recording immediately after SDK initialization, do it in `StatusListener` -> `onStateChange` callback as shown in **Status callback** section above.
-
 ### Stop recording
 
 ```kotlin


### PR DESCRIPTION
This is to remove note about starting recording since recording can be started right after SDK init, no need for init to complete