### PR TITLE
fix: Add maven repository URL to Android installation docs

### DIFF
--- a/android_native.mdx
+++ b/android_native.mdx
@@ -21,11 +21,17 @@ applications. This guide covers all aspects of integrating and using the SDK eff
 
 ## Installation
 
-Add the Truemetrics SDK to your app's `build.gradle` file:
+Add the following to your app-level `build.gradle` file:
 
 ```gradle
+repositories {
+    maven {
+        url "https://github.com/TRUE-Metrics-io/truemetrics_android_SDK_p_maven/raw/"
+    }
+}
+
 dependencies {
-    implementation 'io.truemetrics:truemetricssdk:1.4.0'
+    implementation 'io.truemetrics:truemetricssdk:1.4.3'
 }
 ```
 

--- a/android_native.mdx
+++ b/android_native.mdx
@@ -21,7 +21,7 @@ applications. This guide covers all aspects of integrating and using the SDK eff
 
 ## Installation
 
-Add the following to your app-level `build.gradle` file:
+Add the following to your root-level `build.gradle` file (or `settings.gradle`):
 
 ```gradle
 repositories {
@@ -29,7 +29,11 @@ repositories {
         url "https://github.com/TRUE-Metrics-io/truemetrics_android_SDK_p_maven/raw/"
     }
 }
+```
 
+Then add the dependency to your app-level `build.gradle`:
+
+```gradle
 dependencies {
     implementation 'io.truemetrics:truemetricssdk:1.4.3'
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Android installation and build configuration steps, including adding a root-level build.gradle/settings.gradle block and Maven repository setup.
* **Chores**
  * Updated Truemetrics Android SDK dependency to version 1.4.3 for improved stability and minor fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->